### PR TITLE
WSDL Support to resolve issue #32

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Options to the ec2 function are:
    secret.
  * `endpoint` &mdash; Either the region identifier or else the fully qualified
    domain name of the AWS server.
+ * `wsdlVersion` &mdash; The desired wsdl version to use. Optional, as the default has been left as "2011-05-15" in order to be backward compatible.     
 
 The region identifiers are one of the following.
 
@@ -129,6 +130,7 @@ The region identifiers are one of the following.
  * `sa-east-1` &mdash; Sao Paluo.
  * `ap-northeast-1` &mdash; Tokyo.
  * `ap-southeast-1` &mdash; Singapore.
+ * `ap-southeast-2` &mdash; Sydney.
  * `eu-west-1` &mdash; Ireland.
 
 If you do not specify `endpoint` when you construct your `ec2` function, you can
@@ -143,6 +145,7 @@ and a callback.
 var ec2 = require("ec2")({ key: "<REDACTED>"
                          , secret: "<REDACTED>"
                          , endpoint: "us-east-1"
+                         , wsdlVersion: "2012-10-01"
                          })
   , parameters;
 
@@ -166,6 +169,7 @@ argument to the **Node EC2** function.
 var ec2 = require("ec2")({ key: "<REDACTED>"
                          , secret: "<REDACTED>"
                          , endpoint: "us-east-1"
+                         , wsdlVersion: "2012-10-01"
                          })
   , parameters;
 
@@ -184,12 +188,13 @@ ec2({ endpoint: "us-west-2" }, "RunInstances", parameters, function (error, resu
 
 You can also create a new **Node EC2** function that extends configuration of an
 **Node EC2** function. You can use this to create a base function that holds
-your credentials, and specific functions for the specific regions.
+your credentials, and specific functions for the specific regions or wsdl Version.
 
 ```javascript
 var ec2 = require("ec2")({ key: "<REDACTED>" , secret: "<REDACTED>" })
-  , ec2east = ec2({ endpoint: "us-east-1" })
-  , ec2west = ec2({ endpoint: "us-west-2" })
+  , ec2east2012 = ec2({ endpoint: "us-east-1", wsdlVersion: "2012-10-01" })
+  , ec2west2012 = ec2({ endpoint: "us-west-2", wsdlVersion: "2012-10-01" })
+  , ec2east2011 = ec2(endpoint: "us-east-1")
   , parameters
   ;
 

--- a/lib/amazon.js
+++ b/lib/amazon.js
@@ -7,6 +7,7 @@ var http = require("http")
 function amazon (options, vargs) {
   var callback
     , endpoint
+    , wsdlVersion
     , extended
     , key
     , name
@@ -49,8 +50,9 @@ function amazon (options, vargs) {
       };
     case 3:
     case 4:
-      endpoint = options.endpoint, key = options.key, secret = options.secret;
-      invoke(endpoint, key, secret, name, parameters, function(error, response, body) {
+      endpoint = options.endpoint, wsdlVersion = options.wsdlVersion;
+      key = options.key, secret = options.secret;
+      invoke(endpoint, wsdlVersion, key, secret, name, parameters, function(error, response, body) {
         var statusCode;
         if (error) {
           callback(error);

--- a/lib/request.js
+++ b/lib/request.js
@@ -29,7 +29,7 @@ timestamp = function() {
   return date.join("");
 };
 
-invoke = function(endpoint, key, secret, command, parameters, callback) {
+invoke = function(endpoint, wsdlVersion, key, secret, command, parameters, callback) {
   var digest, hmac, key, map, name, names, query, request, toSign, value, _i, _len;
   map = {
     AWSAccessKeyId: key,
@@ -37,7 +37,7 @@ invoke = function(endpoint, key, secret, command, parameters, callback) {
     SignatureMethod: "HmacSHA256",
     Timestamp: timestamp(),
     SignatureVersion: 2,
-    Version: "2011-05-15"
+    Version: wsdlVersion ? wsdlVersion : "2011-05-15"
   };
   for (key in parameters) {
     value = parameters[key];

--- a/t/request/unfiltered.t
+++ b/t/request/unfiltered.t
@@ -4,6 +4,7 @@ var configuration =
 { key: 'AKIAIBI7OMTXJHBKKPRA'
 , secret: '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'
 , endpoint: 'us-east-1'
+, wsdlVersion: '2012-10-01'
 };
 
 require('proof')(1, function (callback) {


### PR DESCRIPTION
Instead of only changing the static WSDL "Version" string which was in the the request.js file, I have added an option to set a configuration parameter named `wsdlVersion`. Any place which the other configuration parameters can be set or overridden, wsdlVersion may be used as well. This change will now allow support for all future updates of the wsdl by Amazon.

In order to be backward compatible for existing projects referencing this project, I have left the old static version as it was `2011-05-15`. Perhaps it's worth setting to the most recent version, though it's a minor point since awz changes the wsdl a number of times each year. 
